### PR TITLE
fix: remove deprecated React pod dependency

### DIFF
--- a/RNLanguages.podspec
+++ b/RNLanguages.podspec
@@ -15,5 +15,4 @@ Pod::Spec.new do |spec|
   spec.source       = { :git => "https://github.com/react-community/react-native-languages.git" }
   spec.source_files = "ios/**/*.{h,m}"
 
-  spec.dependency   "React"
 end


### PR DESCRIPTION
Hi !, 
I remove React pod because I was getting some errors.

When I run the iOS platform, it builds the project, but I got multiple collisions while loading the bundle:
For example:
```
This warning is caused by a @providesModule declaration with the same name across two different files.
./ios/Pods/React/Libraries/Settings/Settings.ios.js
./node_modules/react-native/Libraries/Settings/Settings.ios.js
```

So, ir order to fix it, I removed the React dependency and now it works perfectly.

If after removing the React Pod, you get some error like `bundling failed: Error: Unable to resolve module "PickerIOS"`, then you need to run:
```
yarn start --reset-cache
```

Cheers !